### PR TITLE
Handle images with empty layers

### DIFF
--- a/cmd/dmverity-vhd/main.go
+++ b/cmd/dmverity-vhd/main.go
@@ -168,7 +168,7 @@ func isTar(reader io.Reader) (io.Reader, bool) {
 
 	_, err := tarReader.Next()
 
-	return io.MultiReader(&header, reader), err == nil
+	return io.MultiReader(&header, reader), err == nil || err == io.EOF
 }
 
 func processLocalImage(imageReader io.Reader, onLayer LayerProcessor) (layerDigests map[int]string, layerIDs map[int]string, err error) {


### PR DESCRIPTION
We see a bug where getting hashes for an image which includes a layer that does nothing (such as chmod-ing files which already have those permissions) causes a layer hash which is a blank string.

The root cause is that when checking for layers in the image, we treat TarReader.Next() returning an io.EOF as not a tar file rather than a valid but empty tar file, therefore we don't attempt to generate a hash for it