### PR TITLE
Throw an error if layer hashes are missing

### DIFF
--- a/cmd/dmverity-vhd/main.go
+++ b/cmd/dmverity-vhd/main.go
@@ -579,8 +579,17 @@ var rootHashVHDCommand = cli.Command{
 		}
 
 		// Print the layer number to layer hash
+		var missingLayers []int
 		for layerNumber := 0; layerNumber < len(layerIDs); layerNumber++ {
-			fmt.Fprintf(os.Stdout, "Layer %d root hash: %s\n", layerNumber, layerHashes[layerIDs[layerNumber]])
+			hash, ok := layerHashes[layerIDs[layerNumber]]
+			if !ok {
+				missingLayers = append(missingLayers, layerNumber)
+				continue
+			}
+			fmt.Fprintf(os.Stdout, "Layer %d root hash: %s\n", layerNumber, hash)
+		}
+		if len(missingLayers) > 0 {
+			return fmt.Errorf("missing root hashes for layers: %v", missingLayers)
 		}
 
 		return nil


### PR DESCRIPTION
### Motivation
@SethHollandsworth has found a use case where we don't find hashes for any of the layers of an image. Current behaviour returns no error and just prints empty hashes which is misleading.

This version returns an error if any layer hashes are missing

