### PR TITLE
Add OCI image support 

### DIFF
--- a/cmd/dmverity-vhd/main.go
+++ b/cmd/dmverity-vhd/main.go
@@ -21,7 +21,17 @@ import (
 
 	"github.com/Microsoft/hcsshim/ext4/dmverity"
 	"github.com/Microsoft/hcsshim/ext4/tar2ext4"
+
+	"compress/gzip"
 )
+
+// decompressIfNeeded checks if the data is gzip-compressed and returns a reader
+func decompressIfNeeded(data []byte) (io.Reader, error) {
+	if bytes.HasPrefix(data, []byte{0x1f, 0x8b}) {
+		return gzip.NewReader(bytes.NewReader(data))
+	}
+	return bytes.NewReader(data), nil
+}
 
 const usage = `dmverity-vhd is a command line tool for creating LCOW layer VHDs with dm-verity hashes.`
 
@@ -171,12 +181,14 @@ func isTar(reader io.Reader) (io.Reader, bool) {
 	return io.MultiReader(&header, reader), err == nil || err == io.EOF
 }
 
-func processLocalImage(imageReader io.Reader, onLayer LayerProcessor) (layerDigests map[int]string, layerIDs map[int]string, err error) {
-
+func processLocalImage(imageReader io.Reader, onLayer LayerProcessor) (map[int]string, map[int]string, error) {
 	imageFileReader := tar.NewReader(imageReader)
-	layerIDs = make(map[int]string)
+	files := make(map[string][]byte)
+
+	layerIDs := make(map[int]string)
 	layerDigestCandidates := make(map[string]map[int]string)
 	var configPath string
+
 	for {
 		hdr, err := imageFileReader.Next()
 		if errors.Is(err, io.EOF) {
@@ -186,64 +198,135 @@ func processLocalImage(imageReader io.Reader, onLayer LayerProcessor) (layerDige
 			return nil, nil, err
 		}
 
-		// If the file is a tar, assume it's a layer, and call the callback
-		imageFileReader, isTar := isTar(imageFileReader)
-		if isTar {
-			if err := onLayer(hdr.Name, imageFileReader); err != nil {
+		if hdr.Typeflag == tar.TypeReg {
+			data, err := io.ReadAll(imageFileReader)
+			if err != nil {
 				return nil, nil, err
 			}
-		} else if hdr.Name == "manifest.json" {
+			files[hdr.Name] = data
+		}
+	}
 
-			type Manifest []struct {
-				Config string   `json:"Config"`
-				Layers []string `json:"Layers"`
+	// Check for OCI index.json first
+	if indexData, ok := files["index.json"]; ok {
+		var index struct {
+			Manifests []struct {
+				Digest string `json:"digest"`
+			} `json:"manifests"`
+		}
+		if err := json.Unmarshal(indexData, &index); err != nil {
+			return nil, nil, err
+		}
+
+		if len(index.Manifests) == 0 {
+			return nil, nil, errors.New("empty OCI index.json")
+		}
+
+		manifestDigest := index.Manifests[0].Digest
+		manifestBlobPath := filepath.Join("blobs", strings.Replace(manifestDigest, ":", "/", 1))
+
+		manifestData, ok := files[manifestBlobPath]
+		if !ok {
+			return nil, nil, fmt.Errorf("OCI manifest blob %s missing", manifestBlobPath)
+		}
+
+		var manifest struct {
+			Config struct {
+				Digest string `json:"digest"`
+			} `json:"config"`
+			Layers []struct {
+				Digest string `json:"digest"`
+			} `json:"layers"`
+		}
+		if err := json.Unmarshal(manifestData, &manifest); err != nil {
+			return nil, nil, err
+		}
+
+		layerDigests := make(map[int]string)
+		for i, layer := range manifest.Layers {
+			layerBlobPath := filepath.Join("blobs", strings.Replace(layer.Digest, ":", "/", 1))
+			layerBlob, ok := files[layerBlobPath]
+			if !ok {
+				return nil, nil, fmt.Errorf("OCI layer %s missing", layerBlobPath)
 			}
-			var manifest Manifest
 
-			manifestData, err := io.ReadAll(imageFileReader)
+			layerReader, err := decompressIfNeeded(layerBlob)
 			if err != nil {
 				return nil, nil, err
 			}
 
-			if err := json.Unmarshal(manifestData, &manifest); err != nil {
+			layerID := strings.SplitN(layer.Digest, ":", 2)[1]
+			layerDigests[i] = layerID
+			layerIDs[i] = layerID
+
+			if err := onLayer(layerID, layerReader); err != nil {
 				return nil, nil, err
 			}
+		}
+		return layerDigests, layerIDs, nil
+	}
 
-			configPath = manifest[0].Config
+	// Fallback to Docker legacy manifest.json logic
+	if manifestData, ok := files["manifest.json"]; ok {
+		type Manifest []struct {
+			Config string   `json:"Config"`
+			Layers []string `json:"Layers"`
+		}
+		var manifest Manifest
+		if err := json.Unmarshal(manifestData, &manifest); err != nil {
+			return nil, nil, err
+		}
 
-			for layerNumber, layerID := range manifest[0].Layers {
-				layerIDSplit := strings.Split(layerID, ":")
-				layerIDs[layerNumber] = layerIDSplit[len(layerIDSplit)-1]
-			}
+		configPath = manifest[0].Config
 
-		} else { // Attempt to parse as a config file
+		for layerNumber, layerID := range manifest[0].Layers {
+			layerIDs[layerNumber] = layerID
+		}
 
-			configData, err := io.ReadAll(imageFileReader)
-			if err != nil {
-				return nil, nil, err
-			}
-
-			// Attempt to parse as if it's an image config file, trying each version until one works
-			parsingFunctions := []func([]byte) (map[int]string, error){
+		for fileName, configData := range files {
+			parsingFuncs := []func([]byte) (map[int]string, error){
 				getLayerDigestsV25,
 				getLayerDigestsV24,
 			}
-			for _, parseFunc := range parsingFunctions {
+
+			for _, parseFunc := range parsingFuncs {
 				layerDigestCandidate, err := parseFunc(configData)
 				if err == nil {
-					layerDigestCandidates[hdr.Name] = layerDigestCandidate
+					layerDigestCandidates[fileName] = layerDigestCandidate
 					break
 				}
 			}
 		}
+
+		layerDigests, ok := layerDigestCandidates[configPath]
+		if !ok {
+			return nil, nil, errors.New("config file either not found or failed to parse")
+		}
+
+		// Call onLayer for each Docker layer
+		for i, layerFile := range manifest[0].Layers {
+			layerBlob, ok := files[layerFile]
+			if !ok {
+				return nil, nil, fmt.Errorf("Docker layer file %s missing", layerFile)
+			}
+
+			layerReader, err := decompressIfNeeded(layerBlob)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			layerID := strings.Split(layerDigests[i], ":")[0]
+			layerIDs[i] = layerID
+
+			if err := onLayer(layerID, layerReader); err != nil {
+				return nil, nil, err
+			}
+		}
+
+		return layerDigestCandidates[configPath], layerIDs, nil
 	}
 
-	layerDigests, ok := layerDigestCandidates[configPath]
-	if !ok {
-		return nil, nil, errors.New("config file either not found, or failed to parse")
-	}
-
-	return layerDigests, layerIDs, nil
+	return nil, nil, errors.New("no recognizable image format found")
 }
 
 func processRemoteImage(imageName string, username string, password string, onLayer LayerProcessor) (layerDigests map[int]string, layerIDs map[int]string, err error) {


### PR DESCRIPTION
This PR enhances the `processLocalImage` function to support both OCI and Docker image formats, removing the tool's dependency on Docker-specific files (`manifest.json`). 

**Implementation:** The updated implementation first attempts to parse images using OCI specifications (`index.json`). If OCI parsing fails, it falls back to Docker's legacy image format.

**Motivation:** This change reduces our tooling's dependency on Docker. We have a customer who specifically wanted the flexibility to use Podman or Skopeo instead of Docker in their pipeline (due to Docker not being supported in their environment). This PR helps address that requirement.

Update: Seems to fix the issue with using `-d` (i.e., docker as source of images). I guess “pull from registry” gave us an image format the existing code understood, while the Docker daemon’s locally cached version might have had a different internal layout, which we can now support through this PR. Thanks @KenGordon for catching this!