### PR TITLE
Redirect log to stderr to keep stdout clean

### DIFF
--- a/cmd/dmverity-vhd/main.go
+++ b/cmd/dmverity-vhd/main.go
@@ -39,7 +39,7 @@ func init() {
 		DisableTimestamp: false,
 	})
 
-	log.SetOutput(os.Stdout)
+	log.SetOutput(os.Stderr)
 
 	log.SetLevel(log.WarnLevel)
 	log.Info("Init ran")


### PR DESCRIPTION
This is needed so that confcom can appropriately consume the stdout.